### PR TITLE
Allow routes to specify base paths

### DIFF
--- a/routes/absences.js
+++ b/routes/absences.js
@@ -3,6 +3,8 @@ import { getAbsences } from '../inc/absences.js';
 import { handleResponse } from '../inc/response.js';
 
 const router = express.Router();
+// Base path for this router
+export const routePath = '/absences';
 
 router.get('/:userId/:year?/:month?', handleResponse(async (req, res) => {
     const { userId, year, month } = req.params;

--- a/routes/login.js
+++ b/routes/login.js
@@ -7,6 +7,8 @@ import { handleResponse } from '../inc/response.js';
 
 dotenv.config();
 const router = express.Router();
+// Base path for this router
+export const routePath = '/login';
 
 router.post('/', handleResponse(async (req, res) => {
     const { email, password } = req.body;

--- a/routes/personne.js
+++ b/routes/personne.js
@@ -2,6 +2,8 @@ import express from 'express';
 import { getPersonne, getPersonnes, updatePersonne } from '../inc/personnes.js';
 import { handleResponse } from '../inc/response.js';
 const router = express.Router();
+// Base path for this router
+export const routePath = '/personne';
 
 router.get('/', handleResponse(async (req, res) => {
     const personne = await getPersonne({ id: req.user.personne_id });

--- a/routes/personnes.js
+++ b/routes/personnes.js
@@ -2,6 +2,8 @@ import express from 'express';
 import { getPersonne, getPersonnes, updatePersonne } from '../inc/personnes.js';
 import { handleResponse } from '../inc/response.js';
 const router = express.Router();
+// Base path for this router
+export const routePath = '/personnes';
 
 router.get('/', handleResponse(async (req, res) => {
   const personnes = await getPersonnes();

--- a/routes/users.js
+++ b/routes/users.js
@@ -3,6 +3,8 @@ import { getUsers } from '../inc/users.js';
 import { handleResponse } from '../inc/response.js';
 
 const router = express.Router();
+// Base path for this router
+export const routePath = '/users';
 
 // GET /users/
 router.get('/', handleResponse(async (req, res) => {

--- a/server.js
+++ b/server.js
@@ -105,10 +105,15 @@ const routeFiles = fs.readdirSync(routesDir).filter(file => file.endsWith('.js')
 // Import dynamically using top-level await workaround
 const loadRoutes = async () => {
   for (const file of routeFiles) {
-    const route = await import(`./routes/${file}`);
-    const routeName = `/${path.basename(file, '.js')}`;
-    console.log({file, routeName})
-    app.use(routeName, route.default);
+    const routeModule = await import(`./routes/${file}`);
+    const router = routeModule.default;
+    const routePath = routeModule.routePath;
+    if (!routePath) {
+      console.warn(`No routePath specified in ${file}`);
+      continue;
+    }
+    console.log({file, routePath})
+    app.use(routePath, router);
   }
 };
 


### PR DESCRIPTION
## Summary
- let individual routes specify their own base path via `routePath`
- register routes using the explicit `routePath`

## Testing
- `node --check server.js`
- `node --check routes/login.js`
- `node --check routes/personne.js`
- `node --check routes/personnes.js`
- `node --check routes/absences.js`
- `node --check routes/users.js`


------
https://chatgpt.com/codex/tasks/task_e_685b96f30ae0832fbfe99d613f10d812